### PR TITLE
Re-align the RuntimeDecoder inspector elements

### DIFF
--- a/Packages/com.miner28.avatar-image-reader/Resources/RuntimeDecoderEditor.uss
+++ b/Packages/com.miner28.avatar-image-reader/Resources/RuntimeDecoderEditor.uss
@@ -27,7 +27,7 @@
     margin-left: 3px;
     margin-right: 3px;
     margin-top: 3px;
-    margin-bottom: 3px;
+    margin-bottom: 1px;
 }
 
 .hidden-element {
@@ -36,4 +36,11 @@
 
 .unity-foldout {
     margin-left: 16px;
+}
+
+.unity-foldout > #unity-content {
+    margin-left: -4px;
+    margin-right: 0;
+    margin-top: 0;
+    margin-bottom: 0;
 }

--- a/Packages/com.miner28.avatar-image-reader/Resources/RuntimeDecoderEditor.uxml
+++ b/Packages/com.miner28.avatar-image-reader/Resources/RuntimeDecoderEditor.uxml
@@ -1,9 +1,9 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements">
-    <ui:VisualElement name="Banner" style="flex-direction: row;">
+    <ui:VisualElement name="Banner" style="flex-direction: row; border-left-width: 13px;">
         <Style src="RuntimeDecoderEditor.uss" />
         <ui:Label text="Avatar Image Reader" class="header-large margin-default" style="left: auto;" />
     </ui:VisualElement>
-    <ui:VisualElement name="AvatarPreview">
+    <ui:VisualElement name="AvatarPreview" style="border-left-width: 13px;">
         <Style src="RuntimeDecoderEditor.uss" />
         <ui:VisualElement name="Header" style="flex-direction: row;">
             <ui:Label text="Main Avatar" class="margin-default" style="-unity-font-style: bold;" />

--- a/Packages/com.miner28.avatar-image-reader/Udon Programs/RuntimeDecoder.asset
+++ b/Packages/com.miner28.avatar-image-reader/Udon Programs/RuntimeDecoder.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
   m_Name: RuntimeDecoder
   m_EditorClassIdentifier: 
-  serializedUdonProgramAsset: {fileID: 11400000, guid: fd0c4302a37aa1e4a9a656b7bcbeb670,
+  serializedUdonProgramAsset: {fileID: 11400000, guid: 2961f3514ec7a944581d426ceb3b1d71,
     type: 2}
   udonAssembly: 
   assemblyError: 


### PR DESCRIPTION
The inspector elements should now better aligned with the foldouts and elements on other components

![image](https://user-images.githubusercontent.com/26690821/185594587-774d3b10-19bf-4520-99ea-1f864ad043cf.png)
