### PR TITLE
Improve dependency handling with UPM

### DIFF
--- a/Editor/AvatarImageReader.Editor.asmdef
+++ b/Editor/AvatarImageReader.Editor.asmdef
@@ -1,15 +1,15 @@
 {
     "name": "AvatarImageReader.Editor",
     "references": [
-        "BocuD.VRChatApiTools.Editor",
-        "Unity.TextMeshPro",
-        "UdonSharp.Editor",
-        "VRC.Udon.Serialization.OdinSerializer",
-        "VRC.SDKBase.Editor",
         "AvatarImageReader.Runtime",
-        "UdonSharp.Runtime",
+        "Unity.TextMeshPro",
+        "VRC.SDKBase.Editor",
         "VRC.Udon",
-        "BocuD.VRChatApiTools.Runtime"
+        "VRC.Udon.Serialization.OdinSerializer",
+        "UdonSharp.Runtime",
+        "UdonSharp.Editor",
+        "BocuD.VRChatApiTools.Runtime",
+        "BocuD.VRChatApiTools.Editor"
     ],
     "includePlatforms": [
         "Editor"
@@ -19,7 +19,15 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": [],
+    "defineConstraints": [
+        "VRCHAT_API_TOOLS_IMPORTED"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.bocud.vrcapitools",
+            "expression": "0.2.1",
+            "define": "VRCHAT_API_TOOLS_IMPORTED"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Runtime/AvatarImageReader.Runtime.asmdef
+++ b/Runtime/AvatarImageReader.Runtime.asmdef
@@ -1,9 +1,9 @@
 {
     "name": "AvatarImageReader.Runtime",
     "references": [
+        "Unity.TextMeshPro",
         "VRC.Udon",
         "UdonSharp.Runtime",
-        "Unity.TextMeshPro",
         "BocuD.VRChatApiTools.Runtime"
     ],
     "includePlatforms": [],
@@ -12,7 +12,15 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": [],
+    "defineConstraints": [
+        "VRCHAT_API_TOOLS_IMPORTED"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.bocud.vrcapitools",
+            "expression": "0.2.1",
+            "define": "VRCHAT_API_TOOLS_IMPORTED"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/package.json
+++ b/package.json
@@ -16,10 +16,6 @@
   ],
   "unity": "2019.4",
   "unityRelease": "29f1",
-  "dependencies": {
-    "com.vrchat.udonsharp": "1.0.1",
-    "com.bocud.vrcapitools": "0.2.1"
-  },
   "vpmDependencies": {
     "com.vrchat.udonsharp": "1.x.x",
     "com.bocud.vrcapitools": "0.2.1"


### PR DESCRIPTION
Unity shouldn't throw errors anymore when importing before VRChatApiTools without VCC